### PR TITLE
Use standard ROS messages

### DIFF
--- a/optitrack_multiplexer_ros2/src/optitrack_multiplexer.cpp
+++ b/optitrack_multiplexer_ros2/src/optitrack_multiplexer.cpp
@@ -354,10 +354,10 @@ void OptitrackMultiplexer::PublishTf(
   t.transform.translation.x = rigid_body.pose.position.x;
   t.transform.translation.y = rigid_body.pose.position.y;
   t.transform.translation.z = rigid_body.pose.position.z;
-  t.transform.rotation.x = rigid_body.pose.orientation.q_x;
-  t.transform.rotation.y = rigid_body.pose.orientation.q_y;
-  t.transform.rotation.z = rigid_body.pose.orientation.q_z;
-  t.transform.rotation.w = rigid_body.pose.orientation.q_w;
+  t.transform.rotation.x = rigid_body.pose.orientation.x;
+  t.transform.rotation.y = rigid_body.pose.orientation.y;
+  t.transform.rotation.z = rigid_body.pose.orientation.z;
+  t.transform.rotation.w = rigid_body.pose.orientation.w;
 
   tf_broadcaster_->sendTransform(t);
 }

--- a/optitrack_multiplexer_ros2/src/optitrack_multiplexer.cpp
+++ b/optitrack_multiplexer_ros2/src/optitrack_multiplexer.cpp
@@ -219,7 +219,7 @@ void OptitrackMultiplexer::FrameDataCallback(
       ::optitrack_multiplexer_ros2_msgs::msg::RigidBodyStamped
           rigid_body_stamped_msg = rigid_body_stamped_msgs[i];
 
-      rigid_body_stamped_msg.stamp = capture_time;
+      rigid_body_stamped_msg.header.stamp = capture_time;
       rigid_body_stamped_msg.frame = frame_data->frame;
       rigid_body_stamped_msg.latency_ms = total_pipeline_latency;
 
@@ -236,7 +236,7 @@ void OptitrackMultiplexer::FrameDataCallback(
 
       ::optitrack_multiplexer_ros2_msgs::msg::SkeletonStamped
           skeleton_stamped_msg = skeleton_stamped_msgs[i];
-      skeleton_stamped_msg.stamp = capture_time;
+      skeleton_stamped_msg.header.stamp = capture_time;
       skeleton_stamped_msg.frame = frame_data->frame;
       skeleton_stamped_msg.latency_ms = total_pipeline_latency;
 
@@ -252,7 +252,7 @@ void OptitrackMultiplexer::FrameDataCallback(
 
     // publish unlabeled markers
     if (unlabeled_markers_stamped_msg.positions.size() != 0) {
-      unlabeled_markers_stamped_msg.stamp = now();
+      unlabeled_markers_stamped_msg.header.stamp = now();
       unlabeled_markers_stamped_msg.frame = frame_data->frame;
       unlabeled_markers_stamped_msg.latency_ms = total_pipeline_latency;
       unlabeled_markers_publisher_->publish(unlabeled_markers_stamped_msg);

--- a/optitrack_multiplexer_ros2_msgs/CMakeLists.txt
+++ b/optitrack_multiplexer_ros2_msgs/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(optitrack_wrapper_ros2_msgs REQUIRED)
 
 set(MSG_FILES
@@ -21,7 +22,7 @@ set(MSG_FILES
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${MSG_FILES}
-  DEPENDENCIES builtin_interfaces optitrack_wrapper_ros2_msgs
+  DEPENDENCIES builtin_interfaces geometry_msgs optitrack_wrapper_ros2_msgs
 )
 
 ament_package()

--- a/optitrack_multiplexer_ros2_msgs/CMakeLists.txt
+++ b/optitrack_multiplexer_ros2_msgs/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(optitrack_wrapper_ros2_msgs REQUIRED)
 
@@ -22,7 +23,7 @@ set(MSG_FILES
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${MSG_FILES}
-  DEPENDENCIES builtin_interfaces geometry_msgs optitrack_wrapper_ros2_msgs
+  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs optitrack_wrapper_ros2_msgs
 )
 
 ament_package()

--- a/optitrack_multiplexer_ros2_msgs/msg/MarkerBase.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/MarkerBase.msg
@@ -4,7 +4,7 @@ string name
 # marker positions
 geometry_msgs/Point position
 
-# if marker position was pointcloud solved i.e. visible 
+# if marker position was pointcloud solved i.e. visible
 # and we get the position from the cameras,
-# or model filled because of occlusion 
+# or model filled because of occlusion
 bool visible

--- a/optitrack_multiplexer_ros2_msgs/msg/MarkerBase.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/MarkerBase.msg
@@ -2,7 +2,7 @@
 string name
 
 # marker positions
-optitrack_wrapper_ros2_msgs/Point position
+geometry_msgs/Point position
 
 # if marker position was pointcloud solved i.e. visible 
 # and we get the position from the cameras,

--- a/optitrack_multiplexer_ros2_msgs/msg/RigidBodyBase.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/RigidBodyBase.msg
@@ -8,7 +8,7 @@ int32 id
 int32 parent_id
 
 # rigid body pose
-optitrack_wrapper_ros2_msgs/Pose pose
+geometry_msgs/Pose pose
 
 # if the rigid body pose is visible/is being tracked
 bool tracking_valid

--- a/optitrack_multiplexer_ros2_msgs/msg/RigidBodyStamped.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/RigidBodyStamped.msg
@@ -1,5 +1,5 @@
-# time of publication
-builtin_interfaces/Time stamp
+# header stamp contains the time of capture
+std_msgs/Header header
 
 # frame number
 int32 frame

--- a/optitrack_multiplexer_ros2_msgs/msg/SkeletonStamped.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/SkeletonStamped.msg
@@ -1,5 +1,5 @@
-# time of publication
-builtin_interfaces/Time stamp
+# header stamp contains the time of capture
+std_msgs/Header header
 
 # frame number
 int32 frame

--- a/optitrack_multiplexer_ros2_msgs/msg/SkeletonStamped.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/SkeletonStamped.msg
@@ -1,8 +1,8 @@
 # time of publication
 builtin_interfaces/Time stamp
 
-# frame number 
-int32 frame 
+# frame number
+int32 frame
 
 # skeleton id
 int32 id

--- a/optitrack_multiplexer_ros2_msgs/msg/UnlabeledMarkersStamped.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/UnlabeledMarkersStamped.msg
@@ -1,5 +1,5 @@
-# time of publication
-builtin_interfaces/Time stamp
+# header stamp contains the time of publication
+std_msgs/Header header
 
 # frame number
 int32 frame

--- a/optitrack_multiplexer_ros2_msgs/msg/UnlabeledMarkersStamped.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/UnlabeledMarkersStamped.msg
@@ -4,7 +4,7 @@ builtin_interfaces/Time stamp
 # frame number
 int32 frame
 
-# unlabeled markers id: 
+# unlabeled markers id:
 # unlabeled markers can change IDs any time the trajectory is broken
 int32[] id
 

--- a/optitrack_multiplexer_ros2_msgs/msg/UnlabeledMarkersStamped.msg
+++ b/optitrack_multiplexer_ros2_msgs/msg/UnlabeledMarkersStamped.msg
@@ -9,7 +9,7 @@ int32 frame
 int32[] id
 
 # unlabeled markers position
-optitrack_wrapper_ros2_msgs/Point[] positions
+geometry_msgs/Point[] positions
 
 # pipeline total latency in ms just before publishing
 float64 latency_ms

--- a/optitrack_multiplexer_ros2_msgs/package.xml
+++ b/optitrack_multiplexer_ros2_msgs/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>builtin_interfaces</depend>
+  <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>optitrack_wrapper_ros2_msgs</depend>
 

--- a/optitrack_multiplexer_ros2_msgs/package.xml
+++ b/optitrack_multiplexer_ros2_msgs/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
   <depend>optitrack_wrapper_ros2_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/optitrack_wrapper_ros2/include/optitrack_wrapper_ros2/description_message_functions.h
+++ b/optitrack_wrapper_ros2/include/optitrack_wrapper_ros2/description_message_functions.h
@@ -5,9 +5,6 @@
 #include "optitrack_wrapper_ros2_msgs/msg/device_description.hpp"
 #include "optitrack_wrapper_ros2_msgs/msg/force_plate_description.hpp"
 #include "optitrack_wrapper_ros2_msgs/msg/marker_set_description.hpp"
-#include "optitrack_wrapper_ros2_msgs/msg/point.hpp"
-#include "optitrack_wrapper_ros2_msgs/msg/pose.hpp"
-#include "optitrack_wrapper_ros2_msgs/msg/quaternion.hpp"
 #include "optitrack_wrapper_ros2_msgs/msg/rigid_body_description.hpp"
 #include "optitrack_wrapper_ros2_msgs/msg/skeleton_description.hpp"
 

--- a/optitrack_wrapper_ros2/src/data_message_functions.cpp
+++ b/optitrack_wrapper_ros2/src/data_message_functions.cpp
@@ -16,7 +16,7 @@ GetMarkerSetDataMessage(sMarkerSetData *p_ms,
   }
 
   for (int i = 0; i < p_ms->nMarkers; i++) {
-    ::optitrack_wrapper_ros2_msgs::msg::Point point;
+    geometry_msgs::msg::Point point;
     point.x = p_ms->Markers[i][0];
     point.y = p_ms->Markers[i][1];
     point.z = p_ms->Markers[i][2];
@@ -45,10 +45,10 @@ GetRigidBodyDataMessage(sRigidBodyData *p_rb,
   rigid_body_data.pose.position.x = p_rb->x;
   rigid_body_data.pose.position.y = p_rb->y;
   rigid_body_data.pose.position.z = p_rb->z;
-  rigid_body_data.pose.orientation.q_x = p_rb->qx;
-  rigid_body_data.pose.orientation.q_y = p_rb->qy;
-  rigid_body_data.pose.orientation.q_z = p_rb->qz;
-  rigid_body_data.pose.orientation.q_w = p_rb->qw;
+  rigid_body_data.pose.orientation.x = p_rb->qx;
+  rigid_body_data.pose.orientation.y = p_rb->qy;
+  rigid_body_data.pose.orientation.z = p_rb->qz;
+  rigid_body_data.pose.orientation.w = p_rb->qw;
   rigid_body_data.mean_error = p_rb->MeanError;
 
   if (verbose) {

--- a/optitrack_wrapper_ros2/src/description_message_functions.cpp
+++ b/optitrack_wrapper_ros2/src/description_message_functions.cpp
@@ -31,7 +31,7 @@ GetRigidBodyDescriptionMessage(sRigidBodyDescription *p_rb) {
   if (p_rb->MarkerPositions != NULL && p_rb->MarkerRequiredLabels != NULL) {
     for (int marker_idx = 0; marker_idx < p_rb->nMarkers; ++marker_idx) {
       // create position for marker
-      ::optitrack_wrapper_ros2_msgs::msg::Point marker_position;
+      geometry_msgs::msg::Point marker_position;
       marker_position.x = p_rb->MarkerPositions[marker_idx][0];
       marker_position.y = p_rb->MarkerPositions[marker_idx][1];
       marker_position.z = p_rb->MarkerPositions[marker_idx][2];
@@ -125,10 +125,10 @@ GetCameraDescriptionMessage(sCameraDescription *p_camera) {
   camera_description.pose.position.x = p_camera->x;
   camera_description.pose.position.y = p_camera->y;
   camera_description.pose.position.z = p_camera->z;
-  camera_description.pose.orientation.q_x = p_camera->qx;
-  camera_description.pose.orientation.q_y = p_camera->qy;
-  camera_description.pose.orientation.q_z = p_camera->qz;
-  camera_description.pose.orientation.q_w = p_camera->qw;
+  camera_description.pose.orientation.x = p_camera->qx;
+  camera_description.pose.orientation.y = p_camera->qy;
+  camera_description.pose.orientation.z = p_camera->qz;
+  camera_description.pose.orientation.w = p_camera->qw;
   return camera_description;
 }
 } // namespace optitrack_wrapper

--- a/optitrack_wrapper_ros2/src/optitrack_wrapper.cpp
+++ b/optitrack_wrapper_ros2/src/optitrack_wrapper.cpp
@@ -227,7 +227,7 @@ void OptitrackWrapper::ProcessFrame(sFrameOfMocapData *data) {
   }
 
   for (int i = 0; i < data->nOtherMarkers; i++) {
-    ::optitrack_wrapper_ros2_msgs::msg::Point point;
+    geometry_msgs::msg::Point point;
     point.x = data->OtherMarkers[i][0];
     point.y = data->OtherMarkers[i][1];
     point.z = data->OtherMarkers[i][2];

--- a/optitrack_wrapper_ros2_msgs/CMakeLists.txt
+++ b/optitrack_wrapper_ros2_msgs/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 set(MSG_FILES
   "msg/AnalogChannelData.msg"
@@ -22,9 +23,6 @@ set(MSG_FILES
   "msg/Marker.msg"
   "msg/MarkerSetData.msg"
   "msg/MarkerSetDescription.msg"
-  "msg/Point.msg"
-  "msg/Pose.msg"
-  "msg/Quaternion.msg"
   "msg/RigidBodyData.msg"
   "msg/RigidBodyDescription.msg"
   "msg/ServerDescription.msg"
@@ -40,7 +38,7 @@ set(SRV_FILES
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${MSG_FILES}
   ${SRV_FILES}
-  DEPENDENCIES builtin_interfaces
+  DEPENDENCIES builtin_interfaces geometry_msgs
  )
 
 ament_package()

--- a/optitrack_wrapper_ros2_msgs/msg/CameraDescription.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/CameraDescription.msg
@@ -2,4 +2,4 @@
 string name
 
 # camera pose
-Pose pose
+geometry_msgs/Pose pose

--- a/optitrack_wrapper_ros2_msgs/msg/DeviceDescription.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/DeviceDescription.msg
@@ -7,7 +7,7 @@ string name
 # for unique device identification
 string serial_no
 
-# device 'type' code 
+# device 'type' code
 int32 device_type
 
 # channel data type code
@@ -16,5 +16,5 @@ int32 channel_data_type
 # number of currently enbaled/active channels (signals)
 int32 n_channels
 
-# channel 
+# channel
 string[] channel_names

--- a/optitrack_wrapper_ros2_msgs/msg/ForcePlateDescription.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/ForcePlateDescription.msg
@@ -19,7 +19,7 @@ float32[144] cal_mat
 # plate corners, in world (aka Mocap System) coordinates, clockwise from plate +x,+y (refer to C3D spec for details); the dimension is [4][3] to [12] with the same method as cal_mat
 float32[12] corners
 
-# force plate 'type' (refer to C3D spec for details) 
+# force plate 'type' (refer to C3D spec for details)
 int32 plate_type
 
 # 0=Calibrated force data, 1=Raw analog voltages

--- a/optitrack_wrapper_ros2_msgs/msg/ForcePlateDescription.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/ForcePlateDescription.msg
@@ -11,7 +11,7 @@ float32 width
 float32 length
 
 # electrical center offset (from electrical center to geometric center-top of force plate) (manufacturer supplied)
-Point origin
+geometry_msgs/Point origin
 
 # force plate calibration matrix (for raw analog voltage channel type only); the dimension is [12][12] to [144] where [0][0] is [0] and [0][1] is [1] and [1][0] is [12] and [1][1] is [13]
 float32[144] cal_mat

--- a/optitrack_wrapper_ros2_msgs/msg/FrameOfMocapData.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/FrameOfMocapData.msg
@@ -14,7 +14,7 @@ MarkerSetData[] marker_set_data
 int32 n_other_markers
 
 # undefined markers data
-Point[] other_markers
+geometry_msgs/Point[] other_markers
 
 # number of rigid bodies
 int32 n_rigid_bodies

--- a/optitrack_wrapper_ros2_msgs/msg/FrameOfMocapData.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/FrameOfMocapData.msg
@@ -64,7 +64,7 @@ uint64 transmit_timestamp
 # latency between camera mid exposure and camera data recieved (in ms)
 float64 latency_camera_mid_exposure_to_data_received_ms
 
-# latency between camera camera data recieved and transmission (in ms) 
+# latency between camera camera data recieved and transmission (in ms)
 float64 latency_camera_data_received_to_transmission_ms
 
 # latency to transmit to NatNet client (in ms)

--- a/optitrack_wrapper_ros2_msgs/msg/Marker.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/Marker.msg
@@ -1,7 +1,7 @@
 # unique identifier:
 # for active markers (LED light), this is the Active ID. For passive markers (reflective spheres), this is the PointCloud assigned ID.
 # for legacy assets that are created prior to 2.0, this is both AssetID (High-bit) and Member ID (Lo-bit)
-int32 id 
+int32 id
 
 # model id
 int32 model_id
@@ -13,10 +13,10 @@ int32 marker_id
 geometry_msgs/Point position
 
 # marker size
-float32 size                             
+float32 size
 
 
-# host defined parameters. 
+# host defined parameters.
 # 0 : Occluded: if the marker is not visible by the cameras
 bool occluded
 
@@ -42,4 +42,4 @@ bool established
 bool measurement
 
 # marker error residual, in mm/ray i.e. the smallest distance between the ray and the final triangulated position of the marker
-float32 residual                        
+float32 residual

--- a/optitrack_wrapper_ros2_msgs/msg/Marker.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/Marker.msg
@@ -10,7 +10,7 @@ int32 model_id
 int32 marker_id
 
 # position
-Point position
+geometry_msgs/Point position
 
 # marker size
 float32 size                             

--- a/optitrack_wrapper_ros2_msgs/msg/MarkerSetData.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/MarkerSetData.msg
@@ -6,4 +6,4 @@ int32 n_markers
 
 # array of marker data ( [n_markers][3] )
 # marker positions x, y, z
-Point[] markers
+geometry_msgs/Point[] markers

--- a/optitrack_wrapper_ros2_msgs/msg/Point.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/Point.msg
@@ -1,4 +1,0 @@
-# point 32
-float32 x
-float32 y
-float32 z

--- a/optitrack_wrapper_ros2_msgs/msg/Pose.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/Pose.msg
@@ -1,5 +1,0 @@
-# position 
-Point position
-
-# orientation
-Quaternion orientation

--- a/optitrack_wrapper_ros2_msgs/msg/Quaternion.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/Quaternion.msg
@@ -1,5 +1,0 @@
-# quaternion 32
-float32 q_x
-float32 q_y
-float32 q_z
-float32 q_w

--- a/optitrack_wrapper_ros2_msgs/msg/RigidBodyData.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/RigidBodyData.msg
@@ -1,4 +1,4 @@
-# RigidBody identifier. 
+# RigidBody identifier.
 # For rigid body assets, this is the StreamingID value
 # For skeleton assets, this combines both skeleton ID (high-bit) and Bone ID (low-bit).
 int32 id
@@ -9,5 +9,5 @@ geometry_msgs/Pose pose
 # mean measure-to-solve deviation
 float32 mean_error
 
-# RigidBody was successfully tracked in this frame 
+# RigidBody was successfully tracked in this frame
 bool tracking_valid

--- a/optitrack_wrapper_ros2_msgs/msg/RigidBodyData.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/RigidBodyData.msg
@@ -4,7 +4,7 @@
 int32 id
 
 # pose
-Pose pose
+geometry_msgs/Pose pose
 
 # mean measure-to-solve deviation
 float32 mean_error

--- a/optitrack_wrapper_ros2_msgs/msg/RigidBodyDescription.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/RigidBodyDescription.msg
@@ -8,13 +8,13 @@ int32 id
 int32 parent_id
 
 # offset position relative to parent
-Point offset
+geometry_msgs/Point offset
 
 # number of markers associated with this rigid body
 int32 n_markers
 
 # array of marker locations ( [n_markers][3] )
-Point[] marker_positions
+geometry_msgs/Point[] marker_positions
 
 # array of expected marker active labels - 0 if not specified. ( [n_markers] )
 int32[] marker_required_labels

--- a/optitrack_wrapper_ros2_msgs/msg/ServerDescription.msg
+++ b/optitrack_wrapper_ros2_msgs/msg/ServerDescription.msg
@@ -1,4 +1,4 @@
-# host is present and accounted for 
+# host is present and accounted for
 bool host_present
 
 # host computer name
@@ -7,7 +7,7 @@ string host_computer_name
 # host IP address
 uint8[4] host_computer_address
 
-# name of host app 
+# name of host app
 string host_app
 
 # version of host app

--- a/optitrack_wrapper_ros2_msgs/package.xml
+++ b/optitrack_wrapper_ros2_msgs/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
For my project I am comparing the poses from OptiTrack with other sources. It would be easier to compare if all of them are using the standard ROS messages instead of custom message types. The geometry_msgs package defines the [Pose](https://docs.ros.org/en/ros2_packages/humble/api/geometry_msgs/msg/Pose.html) message, which includes the Point and Quaternion. Also, messages with 'Stamped' in its name usually has the timestamp inside of a header ([std_msgs/Header](https://docs.ros.org/en/ros2_packages/humble/api/std_msgs/msg/Header.html)) rather than directly exposing the 'stamp' field. This PR suggests these changes and cleans up unnecessary whitespaces in the message definitions.